### PR TITLE
feat: show theme icon matching current mode

### DIFF
--- a/Blog/src/components/ThemeToggle.astro
+++ b/Blog/src/components/ThemeToggle.astro
@@ -49,19 +49,19 @@
 
   /* Show/hide icons based on theme */
   .sun-icon {
-    display: none;
+    display: block;
   }
 
   .moon-icon {
-    display: block;
+    display: none;
   }
 
   [data-theme='dark'] .sun-icon {
-    display: block;
+    display: none;
   }
 
   [data-theme='dark'] .moon-icon {
-    display: none;
+    display: block;
   }
 </style>
 


### PR DESCRIPTION
## Summary
- show the sun icon in light mode and moon icon in dark mode

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdf682ef4c832787be6948ac7ef496