### PR TITLE
Stabilize theme synchronization

### DIFF
--- a/Blog/src/components/BaseHead.astro
+++ b/Blog/src/components/BaseHead.astro
@@ -81,6 +81,29 @@ const absoluteTwitterImage = finalTwitterImage ? getAbsoluteImageUrl(finalTwitte
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<script is:inline>
+  (() => {
+    const storageKey = 'theme';
+    const doc = document.documentElement;
+    let storedTheme = null;
+
+    try {
+      storedTheme = localStorage.getItem(storageKey);
+    } catch (_) {
+      storedTheme = null;
+    }
+
+    let resolved = storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+    if (!resolved) {
+      const prefersDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+      resolved = prefersDark && typeof prefersDark.matches === 'boolean' && prefersDark.matches ? 'dark' : 'light';
+    }
+
+    doc.setAttribute('data-theme', resolved);
+    doc.classList.toggle('dark', resolved === 'dark');
+    doc.style.colorScheme = resolved;
+  })();
+</script>
 <!-- No favicon for clean design -->
 <meta name="generator" content={Astro.generator} />
 

--- a/Blog/src/components/Giscus.astro
+++ b/Blog/src/components/Giscus.astro
@@ -35,105 +35,209 @@ const {
 )}
 
 <script define:vars={{ repo, repoId, category, categoryId, mapping, lang }}>
-  (function () {
-    // --- THEME RESOLUTION (Astro friendly) ---
-    function readTheme() {
-      // common patterns:
-      // 1) <html class="dark">…</html>
-      // 2) <html data-theme="dark">…</html>
-      // 3) fall back to OS
+  (() => {
+    const managerKey = '__giscusThemeSync__';
+
+    function createManager() {
+      const GISCUS_ORIGIN = 'https://giscus.app';
+      const IFRAME_SELECTOR = 'iframe.giscus-frame';
       const html = document.documentElement;
-      if (html.classList.contains('dark')) return 'dark';
-      const attr = html.getAttribute('data-theme');
-      if (attr === 'dark' || attr === 'light') return attr;
-      return matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
+      const prefersDark = typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : {
+            matches: false,
+            addEventListener: undefined,
+            removeEventListener: undefined,
+            addListener: undefined,
+            removeListener: undefined,
+          };
+      const state = {
+        desiredTheme: 'light',
+        flushHandle: 0,
+      };
 
-    // Avoid duplicate mounts on client navigations
-    function alreadyMounted() {
-      return !!document.querySelector('iframe.giscus-frame');
-    }
+      function readTheme() {
+        if (html.classList.contains('dark')) return 'dark';
+        const attr = html.getAttribute('data-theme');
+        if (attr === 'dark' || attr === 'light') return attr;
+        return prefersDark.matches ? 'dark' : 'light';
+      }
 
-    function mountGiscus(theme) {
-      const container = document.getElementById('giscus-container');
-      if (!container || alreadyMounted()) return;
+      function getContainer() {
+        return document.getElementById('giscus-container');
+      }
 
-      const s = document.createElement('script');
-      s.src = 'https://giscus.app/client.js';
-      s.async = true;
-      s.crossOrigin = 'anonymous';
+      function ensureHidden() {
+        const container = getContainer();
+        if (container) container.style.visibility = 'hidden';
+      }
 
-      // REQUIRED CONFIG – fill with your values
-      s.setAttribute('data-repo', repo);
-      s.setAttribute('data-repo-id', repoId);
-      s.setAttribute('data-category', category);
-      s.setAttribute('data-category-id', categoryId);
+      function showContainer() {
+        const container = getContainer();
+        if (container) container.style.visibility = 'visible';
+      }
 
-      // Typical options (tweak if needed)
-      s.setAttribute('data-mapping', mapping);
-      s.setAttribute('data-strict', '0');
-      s.setAttribute('data-reactions-enabled', '1');
-      s.setAttribute('data-emit-metadata', '0');
-      s.setAttribute('data-input-position', 'bottom');
-      s.setAttribute('data-lang', lang);
+      function getIframe() {
+        const container = getContainer();
+        return container ? container.querySelector(IFRAME_SELECTOR) : null;
+      }
 
-      // CRUCIAL: give Giscus the theme BEFORE it boots
-      s.setAttribute('data-theme', theme);
+      function applyTheme(theme) {
+        const iframe = getIframe();
+        if (!iframe || !iframe.contentWindow) return false;
 
-      container.appendChild(s);
-    }
+        iframe.contentWindow.postMessage(
+          { giscus: { setConfig: { theme } } },
+          GISCUS_ORIGIN
+        );
 
-    function setGiscusTheme(theme) {
-      const iframe = document.querySelector('iframe.giscus-frame');
-      if (!iframe || !iframe.contentWindow) return;
-      iframe.contentWindow.postMessage(
-        { giscus: { setConfig: { theme } } },
-        'https://giscus.app'
-      );
-    }
+        return true;
+      }
 
-    // Reveal only after iframe has the correct theme to avoid "flash"
-    function revealOnLoad() {
-      const container = document.getElementById('giscus-container');
-      const observer = new MutationObserver(() => {
-        const iframe = document.querySelector('iframe.giscus-frame');
-        if (iframe) {
-          // small next-tick to allow Giscus to paint
-          setTimeout(() => { if (container) container.style.visibility = 'visible'; }, 0);
-          observer.disconnect();
+      function flushTheme() {
+        state.flushHandle = 0;
+        if (!applyTheme(state.desiredTheme)) {
+          state.flushHandle = requestAnimationFrame(flushTheme);
         }
-      });
-      observer.observe(document.body, { subtree: true, childList: true });
-    }
+      }
 
-    function boot() {
-      const theme = readTheme();
-      mountGiscus(theme);
-      revealOnLoad();
+      function requestThemeSync(theme) {
+        state.desiredTheme = theme;
+        if (!applyTheme(theme) && !state.flushHandle) {
+          state.flushHandle = requestAnimationFrame(flushTheme);
+        }
+      }
 
-      // Watch for theme toggles: support both class and data-theme
-      const html = document.documentElement;
-      const mo = new MutationObserver(() => setGiscusTheme(readTheme()));
-      mo.observe(html, { attributes: true, attributeFilter: ['class', 'data-theme'] });
+      function waitForIframe() {
+        const existing = getIframe();
+        if (existing) return Promise.resolve(existing);
 
-      // OS theme changes
-      const mql = matchMedia('(prefers-color-scheme: dark)');
-      const onChange = () => setGiscusTheme(readTheme());
-      mql.addEventListener ? mql.addEventListener('change', onChange) : mql.addListener(onChange);
+        const container = getContainer();
+        if (!container) return Promise.resolve(null);
 
-      // Astro client navigations (View Transitions / SPA-ish islands)
-      // When a new page loads, if comments exist and not mounted, mount with current theme.
+        return new Promise((resolve) => {
+          const observer = new MutationObserver(() => {
+            const iframe = getIframe();
+            if (iframe) {
+              observer.disconnect();
+              resolve(iframe);
+            }
+          });
+
+          observer.observe(container, { childList: true });
+
+          setTimeout(() => {
+            observer.disconnect();
+            resolve(getIframe());
+          }, 4000);
+        });
+      }
+
+      function revealWhenReady() {
+        const container = getContainer();
+        if (!container) return;
+
+        const fallback = setTimeout(() => {
+          showContainer();
+        }, 4500);
+
+        waitForIframe().then((iframe) => {
+          if (!iframe) {
+            clearTimeout(fallback);
+            showContainer();
+            return;
+          }
+
+          const reveal = () => {
+            if (applyTheme(state.desiredTheme)) {
+              clearTimeout(fallback);
+              showContainer();
+            } else {
+              requestAnimationFrame(reveal);
+            }
+          };
+
+          iframe.addEventListener('load', () => requestAnimationFrame(reveal), { once: true });
+          requestAnimationFrame(reveal);
+        });
+      }
+
+      function mount(theme) {
+        const container = getContainer();
+        if (!container || container.querySelector(IFRAME_SELECTOR)) return;
+
+        ensureHidden();
+
+        const script = document.createElement('script');
+        script.src = 'https://giscus.app/client.js';
+        script.async = true;
+        script.crossOrigin = 'anonymous';
+
+        script.setAttribute('data-repo', repo);
+        script.setAttribute('data-repo-id', repoId);
+        script.setAttribute('data-category', category);
+        script.setAttribute('data-category-id', categoryId);
+        script.setAttribute('data-mapping', mapping);
+        script.setAttribute('data-strict', '0');
+        script.setAttribute('data-reactions-enabled', '1');
+        script.setAttribute('data-emit-metadata', '0');
+        script.setAttribute('data-input-position', 'bottom');
+        script.setAttribute('data-lang', lang);
+        script.setAttribute('data-theme', theme);
+
+        container.appendChild(script);
+      }
+
+      function syncToCurrentTheme() {
+        requestThemeSync(readTheme());
+      }
+
+      function mountIfNeeded() {
+        const container = getContainer();
+        if (!container) return;
+
+        const currentTheme = readTheme();
+        requestThemeSync(currentTheme);
+
+        if (container.querySelector(IFRAME_SELECTOR)) {
+          showContainer();
+          return;
+        }
+
+        mount(currentTheme);
+        revealWhenReady();
+      }
+
+      const htmlObserver = new MutationObserver(syncToCurrentTheme);
+      htmlObserver.observe(html, { attributes: true, attributeFilter: ['class', 'data-theme'] });
+
+      const handleScheme = () => syncToCurrentTheme();
+      if (typeof prefersDark.addEventListener === 'function') {
+        prefersDark.addEventListener('change', handleScheme);
+      } else if (typeof prefersDark.addListener === 'function') {
+        prefersDark.addListener(handleScheme);
+      }
+
       window.addEventListener('astro:page-load', () => {
-        if (document.getElementById('giscus-container') && !alreadyMounted()) {
-          mountGiscus(readTheme());
-        }
+        mountIfNeeded();
       });
+
+      return {
+        mountIfNeeded,
+        syncToCurrentTheme,
+      };
     }
 
+    const globalScope = window;
+    if (!globalScope[managerKey]) {
+      globalScope[managerKey] = createManager();
+    }
+
+    const manager = globalScope[managerKey];
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', boot, { once: true });
+      document.addEventListener('DOMContentLoaded', () => manager.mountIfNeeded(), { once: true });
     } else {
-      boot();
+      manager.mountIfNeeded();
     }
   })();
 </script>

--- a/Blog/src/components/ThemeToggle.astro
+++ b/Blog/src/components/ThemeToggle.astro
@@ -68,38 +68,96 @@
 </style>
 
 <script>
-  const themeToggle = document.getElementById('theme-toggle');
-  
-  function setTheme(theme: 'light' | 'dark') {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
-  }
+  (() => {
+    const toggle = document.getElementById('theme-toggle');
+    const storageKey = 'theme';
+    const doc = document.documentElement;
+    const scheme = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : { matches: false };
 
-  function toggleTheme() {
-    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
-    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-    setTheme(newTheme);
-  }
-
-  function initializeTheme() {
-    const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    if (savedTheme) {
-      setTheme(savedTheme);
-    } else {
-      setTheme('light');
+    function normalise(theme) {
+      return theme === 'dark' || theme === 'light' ? theme : null;
     }
-  }
 
-  // Add click event listener
-  themeToggle?.addEventListener('click', toggleTheme);
-
-  // Initialize theme on page load
-  document.addEventListener('DOMContentLoaded', initializeTheme);
-
-  // Listen for system theme changes, but only if no theme is saved
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-    if (!localStorage.getItem('theme')) {
-      setTheme('light');
+    function applyThemeAttributes(theme) {
+      if (doc.getAttribute('data-theme') !== theme) {
+        doc.setAttribute('data-theme', theme);
+      }
+      doc.classList.toggle('dark', theme === 'dark');
+      doc.style.colorScheme = theme;
     }
-  });
+
+    function setTheme(theme, persist = true) {
+      const normalised = normalise(theme);
+      if (!normalised) return;
+
+      applyThemeAttributes(normalised);
+
+      if (persist) {
+        try {
+          localStorage.setItem(storageKey, normalised);
+        } catch (_) {
+          // Ignore storage errors (e.g. private mode).
+        }
+      }
+    }
+
+    function getStoredTheme() {
+      try {
+        return normalise(localStorage.getItem(storageKey));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function resolveSystemTheme() {
+      return scheme.matches ? 'dark' : 'light';
+    }
+
+    function getActiveTheme() {
+      return normalise(doc.getAttribute('data-theme')) ?? resolveSystemTheme();
+    }
+
+    function initialiseTheme() {
+      const storedTheme = getStoredTheme();
+      if (storedTheme) {
+        setTheme(storedTheme, false);
+      } else {
+        setTheme(resolveSystemTheme(), false);
+      }
+    }
+
+    if (toggle) {
+      toggle.addEventListener('click', () => {
+        const next = getActiveTheme() === 'dark' ? 'light' : 'dark';
+        setTheme(next);
+      });
+    }
+
+    initialiseTheme();
+
+    const handleSchemeChange = (event) => {
+      if (!getStoredTheme()) {
+        setTheme(event.matches ? 'dark' : 'light', false);
+      }
+    };
+
+    if (typeof scheme.addEventListener === 'function') {
+      scheme.addEventListener('change', handleSchemeChange);
+    } else if (typeof scheme.addListener === 'function') {
+      scheme.addListener(handleSchemeChange);
+    }
+
+    window.addEventListener('storage', (event) => {
+      if (event.key !== storageKey) return;
+
+      const newTheme = normalise(event.newValue);
+      if (newTheme) {
+        setTheme(newTheme, false);
+      } else if (event.newValue === null) {
+        setTheme(resolveSystemTheme(), false);
+      }
+    });
+  })();
 </script>


### PR DESCRIPTION
## Summary
- apply the saved or system theme before paint with a lightweight inline head script so the rest of the UI and scrollbars start in the correct mode
- refactor the Giscus integration into a singleton manager that waits for the iframe, retries theme syncs, and survives Astro navigations without flashes
- harden the theme toggle to normalise values, mirror the `.dark` class and `color-scheme`, and gracefully handle missing storage or matchMedia APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04d4082dc8327b78c54fbdb977421