### PR TITLE
Tighten theme synchronisation and accessibility

### DIFF
--- a/Blog/src/components/BaseHead.astro
+++ b/Blog/src/components/BaseHead.astro
@@ -81,6 +81,30 @@ const absoluteTwitterImage = finalTwitterImage ? getAbsoluteImageUrl(finalTwitte
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
+<script is:inline>
+  (() => {
+    const storageKey = 'theme';
+    const doc = document.documentElement;
+    let storedTheme = null;
+
+    try {
+      storedTheme = localStorage.getItem(storageKey);
+    } catch (_) {
+      storedTheme = null;
+    }
+
+    let resolved = storedTheme === 'dark' || storedTheme === 'light' ? storedTheme : null;
+    if (!resolved) {
+      const prefersDark = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+      resolved = prefersDark && typeof prefersDark.matches === 'boolean' && prefersDark.matches ? 'dark' : 'light';
+    }
+
+    doc.setAttribute('data-theme', resolved);
+    doc.classList.toggle('dark', resolved === 'dark');
+    doc.style.colorScheme = resolved;
+  })();
+</script>
 <!-- No favicon for clean design -->
 <meta name="generator" content={Astro.generator} />
 

--- a/Blog/src/components/Giscus.astro
+++ b/Blog/src/components/Giscus.astro
@@ -35,105 +35,241 @@ const {
 )}
 
 <script define:vars={{ repo, repoId, category, categoryId, mapping, lang }}>
-  (function () {
-    // --- THEME RESOLUTION (Astro friendly) ---
-    function readTheme() {
-      // common patterns:
-      // 1) <html class="dark">…</html>
-      // 2) <html data-theme="dark">…</html>
-      // 3) fall back to OS
+  (() => {
+    const managerKey = '__giscusThemeSync__';
+
+    function createManager() {
+      const GISCUS_ORIGIN = 'https://giscus.app';
+      const IFRAME_SELECTOR = 'iframe.giscus-frame';
       const html = document.documentElement;
-      if (html.classList.contains('dark')) return 'dark';
-      const attr = html.getAttribute('data-theme');
-      if (attr === 'dark' || attr === 'light') return attr;
-      return matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-    }
+      const prefersDark = typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : {
+            matches: false,
+            addEventListener: undefined,
+            removeEventListener: undefined,
+            addListener: undefined,
+            removeListener: undefined,
+          };
+      const state = {
+        desiredTheme: 'light',
+        flushHandle: 0,
+      };
 
-    // Avoid duplicate mounts on client navigations
-    function alreadyMounted() {
-      return !!document.querySelector('iframe.giscus-frame');
-    }
+      function readTheme() {
+        if (html.classList.contains('dark')) return 'dark';
+        const attr = html.getAttribute('data-theme');
+        if (attr === 'dark' || attr === 'light') return attr;
+        return prefersDark.matches ? 'dark' : 'light';
+      }
 
-    function mountGiscus(theme) {
-      const container = document.getElementById('giscus-container');
-      if (!container || alreadyMounted()) return;
+      function getContainer() {
+        return document.getElementById('giscus-container');
+      }
 
-      const s = document.createElement('script');
-      s.src = 'https://giscus.app/client.js';
-      s.async = true;
-      s.crossOrigin = 'anonymous';
+      function ensureHidden() {
+        const container = getContainer();
+        if (container) container.style.visibility = 'hidden';
+      }
 
-      // REQUIRED CONFIG – fill with your values
-      s.setAttribute('data-repo', repo);
-      s.setAttribute('data-repo-id', repoId);
-      s.setAttribute('data-category', category);
-      s.setAttribute('data-category-id', categoryId);
+      function showContainer() {
+        const container = getContainer();
+        if (container) container.style.visibility = 'visible';
+      }
 
-      // Typical options (tweak if needed)
-      s.setAttribute('data-mapping', mapping);
-      s.setAttribute('data-strict', '0');
-      s.setAttribute('data-reactions-enabled', '1');
-      s.setAttribute('data-emit-metadata', '0');
-      s.setAttribute('data-input-position', 'bottom');
-      s.setAttribute('data-lang', lang);
+      function getIframe() {
+        const container = getContainer();
+        return container ? container.querySelector(IFRAME_SELECTOR) : null;
+      }
 
-      // CRUCIAL: give Giscus the theme BEFORE it boots
-      s.setAttribute('data-theme', theme);
+      function applyTheme(theme) {
+        const iframe = getIframe();
+        if (!iframe || !iframe.contentWindow) return false;
 
-      container.appendChild(s);
-    }
+        iframe.contentWindow.postMessage(
+          { giscus: { setConfig: { theme } } },
+          GISCUS_ORIGIN
+        );
 
-    function setGiscusTheme(theme) {
-      const iframe = document.querySelector('iframe.giscus-frame');
-      if (!iframe || !iframe.contentWindow) return;
-      iframe.contentWindow.postMessage(
-        { giscus: { setConfig: { theme } } },
-        'https://giscus.app'
-      );
-    }
+        return true;
+      }
 
-    // Reveal only after iframe has the correct theme to avoid "flash"
-    function revealOnLoad() {
-      const container = document.getElementById('giscus-container');
-      const observer = new MutationObserver(() => {
-        const iframe = document.querySelector('iframe.giscus-frame');
-        if (iframe) {
-          // small next-tick to allow Giscus to paint
-          setTimeout(() => { if (container) container.style.visibility = 'visible'; }, 0);
-          observer.disconnect();
+      function flushTheme() {
+        state.flushHandle = 0;
+        if (!applyTheme(state.desiredTheme)) {
+          state.flushHandle = requestAnimationFrame(flushTheme);
+        }
+      }
+
+      function requestThemeSync(theme) {
+        state.desiredTheme = theme;
+        if (!applyTheme(theme) && !state.flushHandle) {
+          state.flushHandle = requestAnimationFrame(flushTheme);
+        }
+      }
+
+      function waitForIframe() {
+        const existing = getIframe();
+        if (existing) return Promise.resolve(existing);
+
+        const container = getContainer();
+        if (!container) return Promise.resolve(null);
+
+        return new Promise((resolve) => {
+          const observer = new MutationObserver(() => {
+            const iframe = getIframe();
+            if (iframe) {
+              observer.disconnect();
+              resolve(iframe);
+            }
+          });
+
+          observer.observe(container, { childList: true });
+
+          setTimeout(() => {
+            observer.disconnect();
+            resolve(getIframe());
+          }, 4000);
+        });
+      }
+
+      function revealWhenReady() {
+        const container = getContainer();
+        if (!container) return;
+
+        const fallback = setTimeout(() => {
+          showContainer();
+        }, 4500);
+
+        waitForIframe().then((iframe) => {
+          if (!iframe) {
+            clearTimeout(fallback);
+            showContainer();
+            return;
+          }
+
+          const reveal = () => {
+            if (applyTheme(state.desiredTheme)) {
+              clearTimeout(fallback);
+              showContainer();
+            } else {
+              requestAnimationFrame(reveal);
+            }
+          };
+
+          iframe.addEventListener('load', () => requestAnimationFrame(reveal), { once: true });
+          requestAnimationFrame(reveal);
+        });
+      }
+
+      function mount(theme) {
+        const container = getContainer();
+        if (!container || container.querySelector(IFRAME_SELECTOR)) return;
+
+        ensureHidden();
+
+        const script = document.createElement('script');
+        script.src = 'https://giscus.app/client.js';
+        script.async = true;
+        script.crossOrigin = 'anonymous';
+
+        script.setAttribute('data-repo', repo);
+        script.setAttribute('data-repo-id', repoId);
+        script.setAttribute('data-category', category);
+        script.setAttribute('data-category-id', categoryId);
+        script.setAttribute('data-mapping', mapping);
+        script.setAttribute('data-strict', '0');
+        script.setAttribute('data-reactions-enabled', '1');
+        script.setAttribute('data-emit-metadata', '0');
+        script.setAttribute('data-input-position', 'bottom');
+        script.setAttribute('data-lang', lang);
+        script.setAttribute('data-theme', theme);
+
+        container.appendChild(script);
+      }
+
+      function syncToCurrentTheme() {
+        requestThemeSync(readTheme());
+      }
+
+      function mountIfNeeded() {
+        const container = getContainer();
+        if (!container) return;
+
+        const currentTheme = readTheme();
+        requestThemeSync(currentTheme);
+
+        if (container.querySelector(IFRAME_SELECTOR)) {
+          showContainer();
+          return;
+        }
+
+        mount(currentTheme);
+        revealWhenReady();
+      }
+
+      const htmlObserver = new MutationObserver(syncToCurrentTheme);
+      htmlObserver.observe(html, { attributes: true, attributeFilter: ['class', 'data-theme'] });
+
+      const handleScheme = () => syncToCurrentTheme();
+      if (typeof prefersDark.addEventListener === 'function') {
+        prefersDark.addEventListener('change', handleScheme);
+      } else if (typeof prefersDark.addListener === 'function') {
+        prefersDark.addListener(handleScheme);
+      }
+
+      const handlePageLoad = () => {
+        mountIfNeeded();
+      };
+
+      window.addEventListener('astro:page-load', handlePageLoad);
+      window.addEventListener('astro:after-swap', () => {
+        ensureHidden();
+        mountIfNeeded();
+        syncToCurrentTheme();
+      });
+
+      window.addEventListener('astro:before-swap', ensureHidden);
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+          syncToCurrentTheme();
         }
       });
-      observer.observe(document.body, { subtree: true, childList: true });
-    }
 
-    function boot() {
-      const theme = readTheme();
-      mountGiscus(theme);
-      revealOnLoad();
-
-      // Watch for theme toggles: support both class and data-theme
-      const html = document.documentElement;
-      const mo = new MutationObserver(() => setGiscusTheme(readTheme()));
-      mo.observe(html, { attributes: true, attributeFilter: ['class', 'data-theme'] });
-
-      // OS theme changes
-      const mql = matchMedia('(prefers-color-scheme: dark)');
-      const onChange = () => setGiscusTheme(readTheme());
-      mql.addEventListener ? mql.addEventListener('change', onChange) : mql.addListener(onChange);
-
-      // Astro client navigations (View Transitions / SPA-ish islands)
-      // When a new page loads, if comments exist and not mounted, mount with current theme.
-      window.addEventListener('astro:page-load', () => {
-        if (document.getElementById('giscus-container') && !alreadyMounted()) {
-          mountGiscus(readTheme());
+      window.addEventListener('pageshow', (event) => {
+        if (event.persisted) {
+          ensureHidden();
+          mountIfNeeded();
+          syncToCurrentTheme();
         }
       });
+
+      window.addEventListener('themechange', (event) => {
+        const nextTheme = event && event.detail && event.detail.theme;
+        if (nextTheme === 'dark' || nextTheme === 'light') {
+          requestThemeSync(nextTheme);
+        } else {
+          syncToCurrentTheme();
+        }
+      });
+
+      return {
+        mountIfNeeded,
+        syncToCurrentTheme,
+      };
     }
 
+    const globalScope = window;
+    if (!globalScope[managerKey]) {
+      globalScope[managerKey] = createManager();
+    }
+
+    const manager = globalScope[managerKey];
     if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', boot, { once: true });
+      document.addEventListener('DOMContentLoaded', () => manager.mountIfNeeded(), { once: true });
     } else {
-      boot();
+      manager.mountIfNeeded();
     }
   })();
 </script>

--- a/Blog/src/components/Header.astro
+++ b/Blog/src/components/Header.astro
@@ -54,21 +54,23 @@ import { getUrl } from '../utils/url';
 		padding: 0 1.5rem;
 	}
 
-	.nav-wrapper {
-		max-width: 1200px;
-		height: 100%;
-		margin: 0 auto;
-		display: grid;
-		grid-template-columns: auto 1fr auto;
-		align-items: center;
-		gap: 2rem;
-	}
+        .nav-wrapper {
+                max-width: 1200px;
+                height: 100%;
+                margin: 0 auto;
+                display: grid;
+                grid-template-columns: auto 1fr auto;
+                grid-template-areas: 'brand links actions';
+                align-items: center;
+                gap: 2rem;
+        }
 
-	.nav-brand {
-		display: flex;
-		align-items: center;
-		min-width: 0;
-	}
+        .nav-brand {
+                display: flex;
+                align-items: center;
+                min-width: 0;
+                grid-area: brand;
+        }
 
 	.brand-link {
 		display: flex;
@@ -126,13 +128,15 @@ import { getUrl } from '../utils/url';
 		min-width: 0;
 	}
 
-	.nav-links {
-		display: flex;
-		gap: 1rem;
-		align-items: center;
-		justify-content: center;
-		height: 100%;
-	}
+        .nav-links {
+                display: flex;
+                gap: 1rem;
+                align-items: center;
+                justify-content: center;
+                height: 100%;
+                flex-wrap: wrap;
+                grid-area: links;
+        }
 
 	.nav-links a {
 		position: relative;
@@ -156,11 +160,13 @@ import { getUrl } from '../utils/url';
 		font-weight: 600;
 	}
 
-	.nav-actions {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-	}
+        .nav-actions {
+                display: flex;
+                align-items: center;
+                gap: 0.75rem;
+                justify-content: flex-end;
+                grid-area: actions;
+        }
 
 	.social-link {
 		display: flex;
@@ -188,49 +194,84 @@ import { getUrl } from '../utils/url';
 	}
 
 	/* Tablet breakpoint */
-	@media (max-width: 768px) {
-		nav {
-			padding: 0 1rem;
-			height: 3.75rem;
-		}
+        @media (max-width: 768px) {
+                nav {
+                        padding: 0 1rem;
+                        height: 3.75rem;
+                }
 
-		.nav-wrapper {
-			gap: 1.5rem;
-		}
+                .nav-wrapper {
+                        gap: 1.5rem;
+                }
 
-		.brand-text {
-			font-size: 1.05rem;
-		}
+                .brand-text {
+                        font-size: 1.05rem;
+                }
 
-		.brand-icon {
-			width: 2.1rem;
-			height: 2.1rem;
-		}
+                .brand-icon {
+                        width: 2.1rem;
+                        height: 2.1rem;
+                }
 
-		.nav-links {
-			gap: 0.75rem;
-		}
+                .nav-links {
+                        gap: 0.75rem;
+                }
 
-		.nav-links a {
-			padding: 0.45rem 0.65rem;
-			font-size: 0.925rem;
-		}
-	}
+                .nav-links a {
+                        padding: 0.45rem 0.65rem;
+                        font-size: 0.925rem;
+                }
+        }
 
-	/* Mobile breakpoint */
-	@media (max-width: 480px) {
-		nav {
-			height: 3.5rem;
-			padding: 0 0.75rem;
-		}
+        @media (max-width: 640px) {
+                nav {
+                        height: auto;
+                        padding: 0.75rem 0.75rem 1rem;
+                }
 
-		.nav-wrapper {
-			gap: 0.75rem;
-		}
+                .nav-wrapper {
+                        grid-template-columns: 1fr auto;
+                        grid-template-areas:
+                                'brand actions'
+                                'links links';
+                        align-items: center;
+                        row-gap: 0.75rem;
+                        column-gap: 1rem;
+                        width: 100%;
+                }
 
-		.brand-text {
-			font-size: 1rem;
-			max-width: 120px;
+                .nav-links {
+                        justify-content: center;
+                        gap: 0.5rem;
+                        padding-top: 0.25rem;
+                        width: 100%;
+                }
+
+                .nav-links a {
+                        flex: 1 1 calc(50% - 0.5rem);
+                        min-width: 7.5rem;
+                        text-align: center;
+                }
+
+                .nav-actions {
+                        justify-self: end;
+                }
+        }
+
+        /* Mobile breakpoint */
+        @media (max-width: 480px) {
+                nav {
+                        height: auto;
+                        padding: 0.65rem 0.75rem 0.9rem;
+                }
+
+                .nav-wrapper {
+                        gap: 0.5rem;
+                }
+
+                .brand-text {
+                        font-size: 1rem;
+                        max-width: 120px;
 		}
 
 		.brand-icon {
@@ -239,17 +280,19 @@ import { getUrl } from '../utils/url';
 			padding: 0.2rem;
 		}
 
-		.nav-links {
-			gap: 0.35rem;
-		}
+                .nav-links {
+                        gap: 0.35rem;
+                        width: 100%;
+                }
 
-		.nav-links a {
-			padding: 0.4rem 0.5rem;
-			font-size: 0.875rem;
-		}
+                .nav-links a {
+                        padding: 0.4rem 0.5rem;
+                        font-size: 0.875rem;
+                        flex: 1 1 100%;
+                }
 
-		.nav-actions {
-			gap: 0.5rem;
+                .nav-actions {
+                        gap: 0.5rem;
 		}
 
 		.social-link {

--- a/Blog/src/components/ThemeToggle.astro
+++ b/Blog/src/components/ThemeToggle.astro
@@ -3,6 +3,8 @@
   class="theme-toggle"
   title="Toggle theme"
   aria-label="Toggle theme"
+  type="button"
+  aria-pressed="false"
 >
   <svg width="20" height="20" viewBox="0 0 24 24" class="sun-icon">
     <path
@@ -68,38 +70,130 @@
 </style>
 
 <script>
-  const themeToggle = document.getElementById('theme-toggle');
-  
-  function setTheme(theme: 'light' | 'dark') {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
-  }
+  (() => {
+    const toggle = document.getElementById('theme-toggle');
+    const storageKey = 'theme';
+    const doc = document.documentElement;
+    const scheme = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : { matches: false };
 
-  function toggleTheme() {
-    const currentTheme = document.documentElement.getAttribute('data-theme') || 'light';
-    const newTheme = currentTheme === 'light' ? 'dark' : 'light';
-    setTheme(newTheme);
-  }
-
-  function initializeTheme() {
-    const savedTheme = localStorage.getItem('theme') as 'light' | 'dark' | null;
-    if (savedTheme) {
-      setTheme(savedTheme);
-    } else {
-      setTheme('light');
+    function normalise(theme) {
+      return theme === 'dark' || theme === 'light' ? theme : null;
     }
-  }
 
-  // Add click event listener
-  themeToggle?.addEventListener('click', toggleTheme);
-
-  // Initialize theme on page load
-  document.addEventListener('DOMContentLoaded', initializeTheme);
-
-  // Listen for system theme changes, but only if no theme is saved
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-    if (!localStorage.getItem('theme')) {
-      setTheme('light');
+    function resolveSystemTheme() {
+      return scheme.matches ? 'dark' : 'light';
     }
-  });
+
+    let currentTheme = normalise(doc.getAttribute('data-theme')) ?? resolveSystemTheme();
+
+    function applyThemeAttributes(theme) {
+      if (doc.getAttribute('data-theme') !== theme) {
+        doc.setAttribute('data-theme', theme);
+      }
+      doc.classList.toggle('dark', theme === 'dark');
+      doc.style.colorScheme = theme;
+    }
+
+    function updateToggleState(theme) {
+      if (!toggle) return;
+      toggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+      toggle.dataset.theme = theme;
+    }
+
+    function setTheme(theme, persist = true) {
+      const normalised = normalise(theme);
+      if (!normalised) return;
+
+      const changed = normalised !== currentTheme;
+      if (changed) {
+        currentTheme = normalised;
+        applyThemeAttributes(normalised);
+      }
+
+      updateToggleState(normalised);
+
+      if (persist) {
+        try {
+          localStorage.setItem(storageKey, normalised);
+        } catch (_) {
+          // Ignore storage errors (e.g. private mode).
+        }
+      }
+
+      if (changed) {
+        window.dispatchEvent(new CustomEvent('themechange', { detail: { theme: normalised } }));
+      }
+    }
+
+    function getStoredTheme() {
+      try {
+        return normalise(localStorage.getItem(storageKey));
+      } catch (_) {
+        return null;
+      }
+    }
+
+    function getActiveTheme() {
+      const attrTheme = normalise(doc.getAttribute('data-theme'));
+      if (attrTheme && attrTheme !== currentTheme) {
+        currentTheme = attrTheme;
+      }
+      return currentTheme;
+    }
+
+    function initialiseTheme() {
+      const storedTheme = getStoredTheme();
+      if (storedTheme) {
+        setTheme(storedTheme, false);
+      } else {
+        setTheme(getActiveTheme(), false);
+      }
+    }
+
+    if (toggle) {
+      updateToggleState(currentTheme);
+      toggle.addEventListener('click', () => {
+        const next = getActiveTheme() === 'dark' ? 'light' : 'dark';
+        setTheme(next);
+      });
+    }
+
+    initialiseTheme();
+
+    const handleSchemeChange = (event) => {
+      if (!getStoredTheme()) {
+        setTheme(event.matches ? 'dark' : 'light', false);
+      }
+    };
+
+    if (typeof scheme.addEventListener === 'function') {
+      scheme.addEventListener('change', handleSchemeChange);
+    } else if (typeof scheme.addListener === 'function') {
+      scheme.addListener(handleSchemeChange);
+    }
+
+    window.addEventListener('storage', (event) => {
+      if (event.key !== storageKey) return;
+
+      const newTheme = normalise(event.newValue);
+      if (newTheme) {
+        setTheme(newTheme, false);
+      } else if (event.newValue === null) {
+        setTheme(resolveSystemTheme(), false);
+      }
+    });
+
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted) {
+        const storedTheme = getStoredTheme();
+        if (storedTheme) {
+          setTheme(storedTheme, false);
+        } else {
+          setTheme(resolveSystemTheme(), false);
+        }
+      }
+    });
+  })();
 </script>

--- a/Blog/src/layouts/BlogPost.astro
+++ b/Blog/src/layouts/BlogPost.astro
@@ -61,36 +61,37 @@ const safeTags = tags ?? [];
 			no_index={no_index}
 		/>
 		<style>
-			main {
-				width: calc(100% - 2em);
-				max-width: 100%;
-				margin: 0;
-			}
-			.hero-image {
-				width: 100%;
-				margin: 2rem 0;
-			}
-			.hero-image img {
-				display: block;
-				margin: 0 auto;
-				border-radius: 12px;
-				box-shadow: var(--box-shadow);
-				max-width: 100%;
-				height: auto;
-			}
-			.prose {
-				width: 920px;
-				max-width: calc(100% - 2em);
-				margin: auto;
-				padding: 1em;
-				color: rgb(var(--gray-dark));
-			}
-			.title {
-				margin-bottom: 1em;
-				padding: 1em 0;
-				text-align: center;
-				line-height: 1;
-			}
+                        main {
+                                width: 100%;
+                                max-width: 1100px;
+                                margin: 0 auto;
+                                padding: clamp(2.5rem, 7vw, 3.5rem) clamp(1.25rem, 6vw, 2.5rem);
+                        }
+                        .hero-image {
+                                width: 100%;
+                                margin: clamp(1.5rem, 5vw, 2.5rem) 0;
+                        }
+                        .hero-image img {
+                                display: block;
+                                margin: 0 auto;
+                                border-radius: 12px;
+                                box-shadow: var(--box-shadow);
+                                max-width: 100%;
+                                height: auto;
+                        }
+                        .prose {
+                                width: 100%;
+                                max-width: min(70ch, 100%);
+                                margin: 0 auto;
+                                padding: clamp(1.5rem, 5vw, 2.5rem);
+                                color: rgb(var(--gray-dark));
+                        }
+                        .title {
+                                margin-bottom: 1em;
+                                padding: clamp(1rem, 4vw, 1.5rem) 0;
+                                text-align: center;
+                                line-height: 1;
+                        }
 			.title h1 {
 				margin: 0 0 0.5em 0;
 			}
@@ -103,13 +104,13 @@ const safeTags = tags ?? [];
 				margin-bottom: 0.5em;
 				color: rgb(var(--gray));
 			}
-			.tags {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 0.5em;
-				margin: 1em 0;
-				justify-content: center;
-			}
+                        .tags {
+                                display: flex;
+                                flex-wrap: wrap;
+                                gap: 0.5em;
+                                margin: 1em 0;
+                                justify-content: center;
+                        }
 			.tag {
 				background-color: rgba(var(--gray-light), 0.8);
 				color: rgb(var(--gray-dark));
@@ -137,7 +138,24 @@ const safeTags = tags ?? [];
 				border-radius: 0.5rem;
 				margin: 1rem 0;
 			}
-		</style>
+                        @media (max-width: 600px) {
+                                main {
+                                        padding: clamp(2rem, 7vw, 2.75rem) clamp(1rem, 5vw, 1.75rem);
+                                }
+
+                                .prose {
+                                        padding: clamp(1.25rem, 6vw, 2rem);
+                                }
+
+                                .title {
+                                        text-align: left;
+                                }
+
+                                .tags {
+                                        justify-content: flex-start;
+                                }
+                        }
+                </style>
 	</head>
 
 	<body>

--- a/Blog/src/layouts/NotesLayout.astro
+++ b/Blog/src/layouts/NotesLayout.astro
@@ -81,24 +81,24 @@ const breadcrumbs = breadcrumbFrom(currentPath);
                 color: var(--obsidian-text);
             }
             
-            main { 
-                flex: 1; 
-                width: 100%; 
-                max-width: 1400px; 
-                margin: 0 auto; 
-                padding: 1.5rem; 
-                display: grid; 
-                grid-template-columns: 320px 1fr; 
-                gap: 1.5rem; 
+            main {
+                flex: 1;
+                width: 100%;
+                max-width: 1400px;
+                margin: 0 auto;
+                padding: clamp(1.5rem, 4vw, 2.5rem);
+                display: grid;
+                grid-template-columns: 320px 1fr;
+                gap: clamp(1.25rem, 4vw, 2rem);
             }
-            
-            .sidebar { 
-                position: sticky; 
-                top: 4.5rem; 
-                height: calc(100vh - 5rem); 
-                overflow: auto; 
-                padding: 1rem; 
-                border-radius: 0.75rem; 
+
+            .sidebar {
+                position: sticky;
+                top: 4.5rem;
+                height: calc(100vh - 5rem);
+                overflow: auto;
+                padding: clamp(0.85rem, 3vw, 1.1rem);
+                border-radius: 0.75rem;
                 background: var(--obsidian-bg-secondary);
                 border: 1px solid var(--obsidian-border);
             }
@@ -213,10 +213,10 @@ const breadcrumbs = breadcrumbFrom(currentPath);
                 color: var(--obsidian-text-secondary);
             }
             
-            .content { 
-                padding: 2rem; 
-                border-radius: 0.75rem; 
-                background: var(--obsidian-bg-secondary); 
+            .content {
+                padding: clamp(1.75rem, 4vw, 2.5rem);
+                border-radius: 0.75rem;
+                background: var(--obsidian-bg-secondary);
                 border: 1px solid var(--obsidian-border);
                 box-shadow: 0 4px 6px rgba(0,0,0,0.1);
             }
@@ -323,10 +323,10 @@ const breadcrumbs = breadcrumbFrom(currentPath);
                 font-size: 1.1rem; 
             }
             
-            .attachment-list { 
-                display: grid; 
-                grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); 
-                gap: 0.75rem; 
+            .attachment-list {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+                gap: 0.75rem;
             }
             
             .attachment-item { 
@@ -385,14 +385,29 @@ const breadcrumbs = breadcrumbFrom(currentPath);
                 height: auto;
             }
             
-            @media (max-width: 980px) { 
-                main { 
-                    grid-template-columns: 1fr; 
-                } 
-                .sidebar { 
-                    position: static; 
-                    height: auto; 
-                } 
+            @media (max-width: 980px) {
+                main {
+                    grid-template-columns: 1fr;
+                    gap: clamp(1rem, 5vw, 1.5rem);
+                }
+                .sidebar {
+                    position: static;
+                    height: auto;
+                }
+            }
+
+            @media (max-width: 640px) {
+                main {
+                    padding: clamp(1.25rem, 6vw, 1.75rem);
+                }
+
+                .sidebar {
+                    padding: clamp(0.75rem, 5vw, 1rem);
+                }
+
+                .content {
+                    padding: clamp(1.25rem, 6vw, 1.75rem);
+                }
             }
         </style>
     </head>

--- a/Blog/src/pages/blog.astro
+++ b/Blog/src/pages/blog.astro
@@ -39,7 +39,7 @@ const posts = (await getCollection('blog'))
                 width: 100%;
                 max-width: 1400px;
                 margin: 0 auto;
-                padding: 2rem;
+                padding: clamp(2rem, 5vw, 3rem) clamp(1.5rem, 6vw, 3rem);
                 display: flex;
                 flex-direction: column;
             }
@@ -47,7 +47,7 @@ const posts = (await getCollection('blog'))
             .blog-header {
                 text-align: center;
                 margin-bottom: 4rem;
-                padding: 4rem 1rem;
+                padding: clamp(3.5rem, 9vw, 4.5rem) clamp(1.5rem, 6vw, 2.5rem);
                 background: linear-gradient(
                     180deg,
                     rgba(var(--accent), 0.08) 0%,
@@ -57,7 +57,7 @@ const posts = (await getCollection('blog'))
             }
 
             .blog-title {
-                font-size: 3rem;
+                font-size: clamp(2.25rem, 6vw, 3rem);
                 font-weight: 800;
                 color: rgb(var(--black));
                 margin-bottom: 1rem;
@@ -65,17 +65,17 @@ const posts = (await getCollection('blog'))
             }
 
             .blog-description {
-                font-size: 1.25rem;
+                font-size: clamp(1.05rem, 3.2vw, 1.25rem);
                 color: rgb(var(--gray));
-                max-width: 600px;
+                max-width: 640px;
                 line-height: 1.6;
                 margin: 0 auto;
             }
 
             .posts-grid {
                 display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-                gap: 2rem;
+                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+                gap: clamp(1.5rem, 4vw, 2.5rem);
                 margin-bottom: 2rem;
             }
 
@@ -89,8 +89,12 @@ const posts = (await getCollection('blog'))
             }
 
             @media (max-width: 768px) {
+                main {
+                    padding: clamp(1.75rem, 6vw, 2.25rem) clamp(1.25rem, 5vw, 2rem);
+                }
+
                 .blog-header {
-                    padding: 3rem 1rem;
+                    padding: clamp(3rem, 10vw, 3.5rem) clamp(1.25rem, 5vw, 2rem);
                     margin-bottom: 3rem;
                 }
 
@@ -99,13 +103,25 @@ const posts = (await getCollection('blog'))
                 }
 
                 .blog-description {
-                    font-size: 1.125rem;
-                    padding: 0 1rem;
+                    font-size: 1.1rem;
+                    padding: 0;
                 }
 
                 .posts-grid {
                     grid-template-columns: 1fr;
                     gap: 1.5rem;
+                }
+            }
+
+            @media (max-width: 600px) {
+                .blog-header {
+                    text-align: left;
+                }
+
+                .blog-description {
+                    margin-left: 0;
+                    margin-right: 0;
+                    text-align: left;
                 }
             }
         </style>

--- a/Blog/src/pages/index.astro
+++ b/Blog/src/pages/index.astro
@@ -160,13 +160,13 @@ const posts = (await getCollection('blog'))
 		padding: 0;
 	}
 
-	.hero {
-		padding: 8rem 1rem;
-		text-align: center;
-		background: transparent;
-		position: relative;
-		overflow: hidden;
-	}
+        .hero {
+                padding: clamp(5rem, 12vw, 8rem) clamp(1.5rem, 6vw, 3rem);
+                text-align: center;
+                background: transparent;
+                position: relative;
+                overflow: hidden;
+        }
 
 	.hero::before {
 		content: '';
@@ -184,11 +184,12 @@ const posts = (await getCollection('blog'))
 		z-index: -1;
 	}
 
-	.hero-content {
-		max-width: 800px;
-		margin: 0 auto;
-		position: relative;
-	}
+        .hero-content {
+                max-width: min(960px, 100%);
+                margin: 0 auto;
+                position: relative;
+                padding: 0 clamp(0rem, 3vw, 1rem);
+        }
 
 	.hero-badge {
 		display: inline-block;
@@ -202,14 +203,14 @@ const posts = (await getCollection('blog'))
 		transition: var(--theme-transition);
 	}
 
-	.hero h1 {
-		font-size: 3.5rem;
-		font-weight: 700;
-		margin-bottom: 1.5rem;
-		color: rgb(var(--black));
-		line-height: 1.1;
-		letter-spacing: -0.02em;
-	}
+        .hero h1 {
+                font-size: clamp(2.75rem, 7vw, 3.5rem);
+                font-weight: 700;
+                margin-bottom: 1.5rem;
+                color: rgb(var(--black));
+                line-height: 1.1;
+                letter-spacing: -0.02em;
+        }
 
 	.name-blue {
 		background: linear-gradient(135deg, #3b82f6, #1d4ed8);
@@ -218,20 +219,23 @@ const posts = (await getCollection('blog'))
 		background-clip: text;
 	}
 
-	.hero-description {
-		font-size: 1.25rem;
-		color: rgb(var(--gray));
-		max-width: 600px;
-		margin: 0 auto 3rem;
-		line-height: 1.6;
-	}
+        .hero-description {
+                font-size: clamp(1.05rem, 3vw, 1.25rem);
+                color: rgb(var(--gray));
+                max-width: 600px;
+                margin: 0 auto clamp(2.5rem, 8vw, 3rem);
+                line-height: 1.6;
+        }
 
-	.cta-buttons {
-		display: flex;
-		gap: 1rem;
-		justify-content: center;
-		flex-wrap: wrap;
-	}
+        .cta-buttons {
+                display: flex;
+                gap: 1rem;
+                justify-content: center;
+                flex-wrap: wrap;
+                max-width: 32rem;
+                width: 100%;
+                margin: 0 auto;
+        }
 
 	.primary-button, .secondary-button {
 		display: inline-flex;
@@ -317,16 +321,17 @@ const posts = (await getCollection('blog'))
 		opacity: 0.8;
 	}
 
-	.areas-focus {
-		padding: 6rem 1rem;
-		background: linear-gradient(135deg, rgba(248, 250, 252, 0.5), rgba(241, 245, 249, 0.3));
-	}
+        .areas-focus {
+                padding: clamp(4.5rem, 9vw, 6rem) clamp(1.5rem, 6vw, 3rem);
+                background: linear-gradient(135deg, rgba(248, 250, 252, 0.5), rgba(241, 245, 249, 0.3));
+        }
 
-	.areas-content {
-		max-width: 1200px;
-		margin: 0 auto;
-		text-align: center;
-	}
+        .areas-content {
+                max-width: 1200px;
+                margin: 0 auto;
+                text-align: center;
+                padding: 0 clamp(1rem, 5vw, 2rem);
+        }
 
 	.areas-focus h2 {
 		font-size: 2.5rem;
@@ -337,30 +342,30 @@ const posts = (await getCollection('blog'))
 		letter-spacing: -0.02em;
 	}
 
-	.areas-description {
-		font-size: 1.125rem;
-		color: rgb(var(--gray));
-		margin-bottom: 2rem;
-		max-width: 600px;
-		margin-left: auto;
-		margin-right: auto;
-	}
+        .areas-description {
+                font-size: clamp(1rem, 3vw, 1.125rem);
+                color: rgb(var(--gray));
+                margin-bottom: 2rem;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+        }
 
-	.areas-grid {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: 1.5rem;
-		margin-top: 2rem;
-		max-width: 800px;
-		margin-left: auto;
-		margin-right: auto;
-	}
+        .areas-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+                gap: clamp(1.25rem, 3vw, 1.75rem);
+                margin-top: 2rem;
+                max-width: min(960px, 100%);
+                margin-left: auto;
+                margin-right: auto;
+        }
 
-	.area-card {
-		background: rgba(255, 255, 255, 0.9);
-		padding: 1.5rem;
-		border-radius: 0.75rem;
-		text-align: left;
+        .area-card {
+                background: rgba(255, 255, 255, 0.9);
+                padding: clamp(1.5rem, 4vw, 1.75rem);
+                border-radius: 0.75rem;
+                text-align: left;
 		box-shadow: 0 4px 6px rgba(59, 130, 246, 0.05), 0 1px 3px rgba(0, 0, 0, 0.1);
 		border: 1px solid rgba(59, 130, 246, 0.1);
 		transition: all 0.2s ease;
@@ -452,11 +457,11 @@ const posts = (await getCollection('blog'))
 		font-size: 0.9rem;
 	}
 
-	.latest-posts {
-		padding: 6rem 1rem;
-		max-width: 1200px;
-		margin: 0 auto;
-	}
+        .latest-posts {
+                padding: clamp(4.5rem, 9vw, 6rem) clamp(1.5rem, 6vw, 3rem);
+                max-width: 1200px;
+                margin: 0 auto;
+        }
 
 	.posts-content {
 		text-align: center;
@@ -471,21 +476,21 @@ const posts = (await getCollection('blog'))
 		letter-spacing: -0.02em;
 	}
 
-	.posts-description {
-		font-size: 1.125rem;
-		color: rgb(var(--gray));
-		margin-bottom: 3rem;
-		max-width: 600px;
-		margin-left: auto;
-		margin-right: auto;
-	}
+        .posts-description {
+                font-size: clamp(1rem, 3vw, 1.125rem);
+                color: rgb(var(--gray));
+                margin-bottom: 3rem;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+        }
 
-	.post-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-		gap: 2rem;
-		margin-bottom: 3rem;
-	}
+        .post-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+                gap: clamp(1.5rem, 4vw, 2.5rem);
+                margin-bottom: 3rem;
+        }
 
 	.view-all {
 		text-align: center;
@@ -516,57 +521,89 @@ const posts = (await getCollection('blog'))
 		opacity: 0.8;
 	}
 
-	@media (max-width: 768px) {
-		.hero {
-			padding: 4rem 1rem;
-		}
+        @media (max-width: 768px) {
+                .hero {
+                        padding: clamp(3.5rem, 12vw, 4.5rem) clamp(1.25rem, 5vw, 2rem);
+                }
 
-		.hero h1 {
-			font-size: 2.5rem;
-		}
+                .hero h1 {
+                        font-size: clamp(2.25rem, 8vw, 2.75rem);
+                }
 
-		.hero-description {
-			font-size: 1.1rem;
-		}
+                .hero-description {
+                        font-size: 1.05rem;
+                }
 
-		.cta-buttons {
-			flex-direction: column;
-			align-items: center;
-		}
+                .cta-buttons {
+                        flex-direction: column;
+                        align-items: stretch;
+                        max-width: none;
+                }
 
-		.primary-button, .secondary-button {
-			justify-content: center;
-		}
+                .primary-button, .secondary-button {
+                        justify-content: center;
+                        width: 100%;
+                }
 
-		.areas-focus {
-			padding: 4rem 1rem;
-		}
+                .areas-focus {
+                        padding: clamp(3.5rem, 10vw, 4.5rem) clamp(1.25rem, 5vw, 2rem);
+                }
 
-		.areas-focus h2 {
-			font-size: 2rem;
-		}
+                .areas-focus h2 {
+                        font-size: 2rem;
+                }
 
-		.areas-grid {
-			grid-template-columns: 1fr;
-			gap: 1rem;
-			max-width: 100%;
-		}
+                .areas-grid {
+                        grid-template-columns: 1fr;
+                        gap: 1rem;
+                        max-width: 100%;
+                }
 
-		.area-card {
-			padding: 1.25rem;
-		}
+                .area-card {
+                        padding: clamp(1.25rem, 5vw, 1.5rem);
+                }
 
-		.latest-posts {
-			padding: 4rem 1rem;
-		}
+                .latest-posts {
+                        padding: clamp(3.5rem, 10vw, 4.5rem) clamp(1.25rem, 5vw, 2rem);
+                }
 
-		.post-grid {
-			grid-template-columns: 1fr;
-			gap: 1.5rem;
-		}
+                .post-grid {
+                        grid-template-columns: 1fr;
+                        gap: 1.5rem;
+                }
 
-		.view-all {
-			margin-top: 1.5rem;
-		}
-	}
+                .view-all {
+                        margin-top: 1.5rem;
+                }
+        }
+
+        @media (max-width: 600px) {
+                .hero {
+                        text-align: left;
+                }
+
+                .hero-content {
+                        text-align: left;
+                        padding: 0;
+                }
+
+                .hero-badge {
+                        margin-left: 0;
+                        margin-right: auto;
+                }
+
+                .hero-description {
+                        margin: 0 0 clamp(2rem, 7vw, 2.5rem);
+                }
+
+                .cta-buttons {
+                        margin: 0;
+                        align-items: stretch;
+                }
+
+                .primary-button,
+                .secondary-button {
+                        width: 100%;
+                }
+        }
 </style>

--- a/Blog/src/styles/global.css
+++ b/Blog/src/styles/global.css
@@ -77,10 +77,10 @@ body {
 }
 
 main {
-	width: 920px;
-	max-width: calc(100% - 2em);
-	margin: auto;
-	padding: 3em 1em;
+        width: min(920px, 100%);
+        max-width: 100%;
+        margin: 0 auto;
+        padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1.25rem, 6vw, 2.5rem);
 }
 
 h1,
@@ -239,29 +239,29 @@ li {
 }
 
 @media (max-width: 720px) {
-	body {
-		font-size: 1rem;
-	}
-	
-	h1 {
-		font-size: 2rem;
-	}
-	
-	h2 {
-		font-size: 1.5rem;
-	}
-	
-	h3 {
-		font-size: 1.25rem;
-	}
-	
-	main {
-		padding: 1em;
-	}
+        body {
+                font-size: 1rem;
+        }
 
-	.prose p {
-		margin-bottom: 1.25em;
-	}
+        h1 {
+                font-size: 2rem;
+        }
+
+        h2 {
+                font-size: 1.5rem;
+        }
+
+        h3 {
+                font-size: 1.25rem;
+        }
+
+        main {
+                padding: clamp(1.5rem, 6vw, 2rem) clamp(1rem, 6vw, 1.5rem);
+        }
+
+        .prose p {
+                margin-bottom: 1.25em;
+        }
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- declare the document supports light and dark color schemes so the browser paints system UI elements consistently from first paint
- harden the theme toggle by tracking the active theme, syncing aria-pressed state, dispatching themechange events, and re-reading preferences after bfcache restores
- extend the Giscus manager to listen for the new themechange signal and Astro navigation/visibility lifecycle hooks so the iframe always mounts with the current palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d04d4082dc8327b78c54fbdb977421