### PR TITLE
Add view counter to blog posts

### DIFF
--- a/Blog/src/components/ViewCounter.astro
+++ b/Blog/src/components/ViewCounter.astro
@@ -1,0 +1,106 @@
+---
+interface Props {
+        slug: string;
+}
+
+const { slug } = Astro.props;
+const namespace = 'my-website-blog';
+const encodedSlug = encodeURIComponent(slug.toLowerCase());
+const storageKey = `view-counter:${namespace}:${encodedSlug}`;
+---
+
+<style>
+        .view-counter {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.35rem;
+                font-size: 0.95rem;
+                color: rgb(var(--gray));
+        }
+
+        .view-counter svg {
+                width: 1rem;
+                height: 1rem;
+        }
+
+        .view-counter .view-count {
+                font-variant-numeric: tabular-nums;
+                font-weight: 600;
+                color: rgb(var(--gray-dark));
+        }
+
+        [data-theme='dark'] .view-counter {
+                color: rgba(var(--gray-light), 0.85);
+        }
+
+        [data-theme='dark'] .view-counter .view-count {
+                color: rgba(var(--gray-light), 0.95);
+        }
+</style>
+
+<div class="view-counter" data-slug={encodedSlug} data-storage-key={storageKey}>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12c0 0 3.75-6.75 9.75-6.75S21.75 12 21.75 12s-3.75 6.75-9.75 6.75S2.25 12 2.25 12z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 15.75a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5z" />
+        </svg>
+        <span class="view-count" aria-live="polite">--</span>
+        <span class="view-label">views</span>
+</div>
+
+<script>
+        const container = document.currentScript?.previousElementSibling;
+
+        const setCountText = (count) => {
+                if (!container) return;
+                const countElement = container.querySelector('.view-count');
+                if (!countElement) return;
+                countElement.textContent = count;
+        };
+
+        const markAsUnavailable = () => setCountText('—');
+
+        const incrementAndDisplay = async () => {
+                if (!container || typeof window === 'undefined') return;
+
+                const slug = container.getAttribute('data-slug');
+                const storageKey = container.getAttribute('data-storage-key');
+                if (!slug || !storageKey) {
+                        markAsUnavailable();
+                        return;
+                }
+
+                const namespace = 'my-website-blog';
+                const endpoint = `https://api.countapi.xyz/hit/${namespace}/${slug}`;
+
+                try {
+                        const response = await fetch(endpoint);
+                        if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+                        const data = await response.json();
+                        if (typeof data.value === 'number') {
+                                const count = data.value.toLocaleString();
+                                setCountText(count);
+                                try {
+                                        window.localStorage.setItem(storageKey, count);
+                                } catch (storageError) {
+                                        console.warn('View counter storage unavailable:', storageError);
+                                }
+                                return;
+                        }
+                        throw new Error('Unexpected response shape');
+                } catch (error) {
+                        console.warn('Failed to update view counter:', error);
+                        try {
+                                const cached = window.localStorage.getItem(storageKey);
+                                if (cached) {
+                                        setCountText(cached);
+                                        return;
+                                }
+                        } catch (storageError) {
+                                console.warn('Unable to access localStorage:', storageError);
+                        }
+                        markAsUnavailable();
+                }
+        };
+
+        incrementAndDisplay();
+</script>

--- a/Blog/src/layouts/BlogPost.astro
+++ b/Blog/src/layouts/BlogPost.astro
@@ -6,8 +6,11 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Giscus from '../components/Giscus.astro';
 import { getUrl } from '../utils/url';
+import ViewCounter from '../components/ViewCounter.astro';
 
-interface Props extends CollectionEntry<'blog'>['data'] {}
+interface Props extends CollectionEntry<'blog'>['data'] {
+    slug: string;
+}
 
 const {
     title,
@@ -33,6 +36,7 @@ const {
     author,
     no_index,
     enable_comments = true,
+    slug,
 } = Astro.props;
 
 const safeTags = tags ?? [];
@@ -127,10 +131,20 @@ const safeTags = tags ?? [];
 				font-size: 1.25em;
 				margin-bottom: 1em;
 			}
-			.date {
-				margin-bottom: 0.5em;
-				color: rgb(var(--gray));
-			}
+                        .meta {
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                                gap: 1.25rem;
+                                flex-wrap: wrap;
+                                margin-bottom: 0.75em;
+                                color: rgb(var(--gray));
+                        }
+
+                        .meta .date {
+                                margin: 0;
+                                color: inherit;
+                        }
 			.tags {
 				display: flex;
 				flex-wrap: wrap;
@@ -174,14 +188,21 @@ const safeTags = tags ?? [];
 			<article>
 				<div class="prose">
 					<div class="title">
-						{created_date && (
-							<div class="date">
-								<FormattedDate date={created_date} />
-								{updated_date && updated_date > created_date && (
-									<span> (Updated: <FormattedDate date={updated_date} />)</span>
-								)}
-							</div>
-						)}
+                                                {(created_date || slug) && (
+                                                        <div class="meta">
+                                                                {created_date && (
+                                                                        <div class="date">
+                                                                                <FormattedDate date={created_date} />
+                                                                                {updated_date && updated_date > created_date && (
+                                                                                        <span>
+                                                                                                {' '}(Updated: <FormattedDate date={updated_date} />)
+                                                                                        </span>
+                                                                                )}
+                                                                        </div>
+                                                                )}
+                                                                {slug && <ViewCounter slug={slug} />}
+                                                        </div>
+                                                )}
 						<h1>{title}</h1>
 						{subtitle && <div class="subtitle">{subtitle}</div>}
 						{safeTags.length > 0 && (

--- a/Blog/src/pages/[...slug].astro
+++ b/Blog/src/pages/[...slug].astro
@@ -19,8 +19,9 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content } = await render(post);
+const resolvedSlug = post.data.slug || post.id.replace(/\.[^/.]+$/, '');
 ---
 
-<BlogPost {...post.data}>
-	<Content />
-</BlogPost> 
+<BlogPost {...post.data} slug={resolvedSlug}>
+        <Content />
+</BlogPost>


### PR DESCRIPTION
## Summary
- add a reusable view counter component that records views via CountAPI
- display the counter in the blog post layout next to the published date
- provide each blog post's slug to the layout so the counter can identify it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87d6141dc83279531ffd8594abc7e