### PR TITLE
Improve Google Analytics tracking consistency

### DIFF
--- a/Blog/src/components/BaseHead.astro
+++ b/Blog/src/components/BaseHead.astro
@@ -76,11 +76,45 @@ const getAbsoluteImageUrl = (imageUrl: string) => {
 const absoluteFeaturedImage = featured_image ? getAbsoluteImageUrl(featured_image) : '';
 const absoluteOgImage = finalOgImage ? getAbsoluteImageUrl(finalOgImage) : '';
 const absoluteTwitterImage = finalTwitterImage ? getAbsoluteImageUrl(finalTwitterImage) : '';
+const measurementId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID ?? 'G-69EC1EJQ1V';
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+{measurementId && (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}></script>
+    <script is:inline>
+      {`(function() {
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${measurementId}', { send_page_view: false });
+
+  var lastTrackedPath = null;
+
+  function trackPageView() {
+    var pagePath = window.location.pathname + window.location.search;
+    if (pagePath === lastTrackedPath) {
+      return;
+    }
+
+    lastTrackedPath = pagePath;
+    gtag('event', 'page_view', {
+      page_location: window.location.href,
+      page_path: pagePath,
+      page_title: document.title
+    });
+  }
+
+  trackPageView();
+  document.addEventListener('astro:page-load', trackPageView);
+})();`}
+    </script>
+  </>
+)}
+
 <script is:inline>
   (() => {
     const storageKey = 'theme';


### PR DESCRIPTION
## Summary
- adjust the Google Analytics snippet to disable the automatic page view and send manual page_view events
- ensure client-side navigations fire page_view events only once per URL to keep GA counts accurate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8fcde3f208327a6cab24ef5eaa5e6