### PR TITLE
Display GA4 view counts on blog posts

### DIFF
--- a/Blog/README.md
+++ b/Blog/README.md
@@ -34,6 +34,7 @@ npm install
 3. Configure your site:
    - Copy `.env.example` to `.env`
    - Update the environment variables for your deployment
+   - Provide Google Analytics credentials (see below) if you want the on-page view counter to show GA page views
 
 4. Start the development server:
 ```bash
@@ -71,6 +72,26 @@ tags:
 | `tags` | No | Array of tags |
 | `featured_image` | No | Hero image URL |
 | `subtitle` | No | Optional subtitle |
+
+### Google Analytics View Counter
+
+The view badge displayed on each blog post can read total page views directly from Google Analytics 4. To enable it:
+
+1. Create a [service account](https://developers.google.com/identity/protocols/oauth2/service-account) that has the **Viewer** role on your GA4 property.
+2. Create a JSON key for that service account and copy the following fields into your deployment environment:
+
+   ```bash
+   GOOGLE_ANALYTICS_PROPERTY_ID=123456789 # numeric GA4 property id (without the properties/ prefix)
+   GOOGLE_ANALYTICS_CLIENT_EMAIL=service-account@project.iam.gserviceaccount.com
+   GOOGLE_ANALYTICS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+   PUBLIC_GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX
+   ```
+
+   > **Tip:** When pasting the private key into `.env`, keep the `\n` escape sequences as shown above so Astro can reconstruct the original key at build time.
+
+3. Deploy with those variables. During the build Astro queries GA4 for each post and embeds the latest total in the generated HTML.
+
+If the credentials are omitted the counter gracefully falls back to a dash (`—`). Trigger a new build whenever you want the displayed totals to refresh.
 
 ## 🎨 Customization
 

--- a/Blog/src/components/BaseHead.astro
+++ b/Blog/src/components/BaseHead.astro
@@ -76,11 +76,45 @@ const getAbsoluteImageUrl = (imageUrl: string) => {
 const absoluteFeaturedImage = featured_image ? getAbsoluteImageUrl(featured_image) : '';
 const absoluteOgImage = finalOgImage ? getAbsoluteImageUrl(finalOgImage) : '';
 const absoluteTwitterImage = finalTwitterImage ? getAbsoluteImageUrl(finalTwitterImage) : '';
+const measurementId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID ?? 'G-69EC1EJQ1V';
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+{measurementId && (
+  <>
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}></script>
+    <script is:inline>
+      {`(function() {
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${measurementId}', { send_page_view: false });
+
+  var lastTrackedPath = null;
+
+  function trackPageView() {
+    var pagePath = window.location.pathname + window.location.search;
+    if (pagePath === lastTrackedPath) {
+      return;
+    }
+
+    lastTrackedPath = pagePath;
+    gtag('event', 'page_view', {
+      page_location: window.location.href,
+      page_path: pagePath,
+      page_title: document.title
+    });
+  }
+
+  trackPageView();
+  document.addEventListener('astro:page-load', trackPageView);
+})();`}
+    </script>
+  </>
+)}
+
 <script is:inline>
   (() => {
     const storageKey = 'theme';

--- a/Blog/src/components/ViewCounter.astro
+++ b/Blog/src/components/ViewCounter.astro
@@ -1,12 +1,32 @@
 ---
+import { getGoogleAnalyticsPageViews } from '../utils/analytics';
+
 interface Props {
         slug: string;
 }
 
 const { slug } = Astro.props;
-const namespace = 'my-website-blog';
-const encodedSlug = encodeURIComponent(slug.toLowerCase());
-const storageKey = `view-counter:${namespace}:${encodedSlug}`;
+const normalizedSlug = slug
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+        .join('/')
+        .toLowerCase();
+const pagePath = normalizedSlug ? `/${normalizedSlug}/` : '/';
+const storageKey = normalizedSlug
+        ? `view-counter:google-analytics:${normalizedSlug}`
+        : 'view-counter:google-analytics:root';
+
+let initialCount: number | null = null;
+
+if (normalizedSlug) {
+        try {
+                initialCount = await getGoogleAnalyticsPageViews(pagePath);
+        } catch (error) {
+                console.error(`Unable to resolve Google Analytics views for ${pagePath}`, error);
+                initialCount = null;
+        }
+}
 ---
 
 <style>
@@ -38,69 +58,82 @@ const storageKey = `view-counter:${namespace}:${encodedSlug}`;
         }
 </style>
 
-<div class="view-counter" data-slug={encodedSlug} data-storage-key={storageKey}>
+<div
+        class="view-counter"
+        data-page-path={pagePath}
+        data-storage-key={storageKey}
+        data-initial-count={typeof initialCount === 'number' ? initialCount : ''}
+>
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12c0 0 3.75-6.75 9.75-6.75S21.75 12 21.75 12s-3.75 6.75-9.75 6.75S2.25 12 2.25 12z" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 15.75a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5z" />
         </svg>
-        <span class="view-count" aria-live="polite">--</span>
+        <span class="view-count" aria-live="polite">
+                {typeof initialCount === 'number' ? initialCount.toLocaleString() : '--'}
+        </span>
         <span class="view-label">views</span>
 </div>
 
 <script>
         const container = document.currentScript?.previousElementSibling;
 
-        const setCountText = (count) => {
-                if (!container) return;
+        if (!container) {
+                console.warn('View counter container missing');
+        } else {
                 const countElement = container.querySelector('.view-count');
-                if (!countElement) return;
-                countElement.textContent = count;
-        };
+                const storageKey = container.getAttribute('data-storage-key') ?? '';
+                const initialCountAttr = container.getAttribute('data-initial-count');
 
-        const markAsUnavailable = () => setCountText('—');
+                const parseCount = (value) => {
+                        if (!value) return null;
+                        const parsed = Number.parseInt(value, 10);
+                        return Number.isNaN(parsed) ? null : parsed;
+                };
 
-        const incrementAndDisplay = async () => {
-                if (!container || typeof window === 'undefined') return;
-
-                const slug = container.getAttribute('data-slug');
-                const storageKey = container.getAttribute('data-storage-key');
-                if (!slug || !storageKey) {
-                        markAsUnavailable();
-                        return;
-                }
-
-                const namespace = 'my-website-blog';
-                const endpoint = `https://api.countapi.xyz/hit/${namespace}/${slug}`;
-
-                try {
-                        const response = await fetch(endpoint);
-                        if (!response.ok) throw new Error(`Request failed with ${response.status}`);
-                        const data = await response.json();
-                        if (typeof data.value === 'number') {
-                                const count = data.value.toLocaleString();
-                                setCountText(count);
-                                try {
-                                        window.localStorage.setItem(storageKey, count);
-                                } catch (storageError) {
-                                        console.warn('View counter storage unavailable:', storageError);
-                                }
+                const setCountText = (count) => {
+                        if (!countElement) return;
+                        if (count === null) {
+                                countElement.textContent = '—';
                                 return;
                         }
-                        throw new Error('Unexpected response shape');
-                } catch (error) {
-                        console.warn('Failed to update view counter:', error);
+                        countElement.textContent = count.toLocaleString();
+                };
+
+                const readFromStorage = () => {
+                        if (!storageKey || typeof window === 'undefined') return null;
                         try {
                                 const cached = window.localStorage.getItem(storageKey);
-                                if (cached) {
-                                        setCountText(cached);
-                                        return;
-                                }
-                        } catch (storageError) {
-                                console.warn('Unable to access localStorage:', storageError);
+                                return parseCount(cached);
+                        } catch (error) {
+                                console.warn('View counter storage unavailable:', error);
+                                return null;
                         }
-                        markAsUnavailable();
-                }
-        };
+                };
 
-        incrementAndDisplay();
+                let resolvedCount = parseCount(initialCountAttr);
+
+                if (resolvedCount === null) {
+                        resolvedCount = readFromStorage();
+                }
+
+                setCountText(resolvedCount);
+
+                if (resolvedCount !== null && storageKey && typeof window !== 'undefined') {
+                        try {
+                                window.localStorage.setItem(storageKey, String(resolvedCount));
+                        } catch (error) {
+                                console.warn('View counter storage unavailable:', error);
+                        }
+                }
+
+                if (typeof window !== 'undefined' && storageKey) {
+                        document.addEventListener('astro:page-load', () => {
+                                const cached = readFromStorage();
+                                if (cached !== null) {
+                                        resolvedCount = cached;
+                                        setCountText(resolvedCount);
+                                }
+                        });
+                }
+        }
 </script>

--- a/Blog/src/utils/analytics.ts
+++ b/Blog/src/utils/analytics.ts
@@ -1,0 +1,127 @@
+import { createSign } from 'node:crypto';
+
+const GOOGLE_TOKEN_AUDIENCE = 'https://oauth2.googleapis.com/token';
+const ANALYTICS_SCOPE = 'https://www.googleapis.com/auth/analytics.readonly';
+
+interface AccessTokenResponse {
+        access_token: string;
+        expires_in: number;
+        token_type: string;
+}
+
+const base64UrlEncode = (value: string | Record<string, unknown>) => {
+        const payload = typeof value === 'string' ? value : JSON.stringify(value);
+        return Buffer.from(payload).toString('base64url');
+};
+
+const requestAccessToken = async (clientEmail: string, privateKey: string): Promise<string> => {
+        const now = Math.floor(Date.now() / 1000);
+        const header = { alg: 'RS256', typ: 'JWT' };
+        const payload = {
+                iss: clientEmail,
+                scope: ANALYTICS_SCOPE,
+                aud: GOOGLE_TOKEN_AUDIENCE,
+                exp: now + 3600,
+                iat: now,
+        };
+
+        const encodedHeader = base64UrlEncode(header);
+        const encodedPayload = base64UrlEncode(payload);
+        const signatureInput = `${encodedHeader}.${encodedPayload}`;
+
+        const signer = createSign('RSA-SHA256');
+        signer.update(signatureInput);
+        signer.end();
+
+        const signature = signer.sign(privateKey, 'base64url');
+        const assertion = `${signatureInput}.${signature}`;
+
+        const response = await fetch(GOOGLE_TOKEN_AUDIENCE, {
+                method: 'POST',
+                headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                        assertion,
+                }),
+        });
+
+        if (!response.ok) {
+                throw new Error(`Failed to obtain access token (${response.status})`);
+        }
+
+        const json = (await response.json()) as AccessTokenResponse;
+        if (!json.access_token) {
+                throw new Error('Access token missing from response');
+        }
+
+        return json.access_token;
+};
+
+const readPageViews = async (
+        accessToken: string,
+        propertyId: string,
+        pagePath: string,
+): Promise<number> => {
+        const response = await fetch(
+                `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+                {
+                        method: 'POST',
+                        headers: {
+                                Authorization: `Bearer ${accessToken}`,
+                                'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                                dateRanges: [
+                                        {
+                                                startDate: '2023-01-01',
+                                                endDate: 'today',
+                                        },
+                                ],
+                                dimensions: [
+                                        { name: 'pagePath' },
+                                ],
+                                metrics: [
+                                        { name: 'screenPageViews' },
+                                ],
+                                dimensionFilter: {
+                                        filter: {
+                                                fieldName: 'pagePath',
+                                                stringFilter: {
+                                                        matchType: 'EXACT',
+                                                        value: pagePath,
+                                                },
+                                        },
+                                },
+                                limit: 1,
+                        }),
+                },
+        );
+
+        if (!response.ok) {
+                throw new Error(`Analytics query failed (${response.status})`);
+        }
+
+        const json = (await response.json()) as {
+                rows?: Array<{ metricValues?: Array<{ value?: string }> }>;
+        };
+
+        const countString = json.rows?.[0]?.metricValues?.[0]?.value;
+        const parsed = countString ? Number.parseInt(countString, 10) : 0;
+        return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+export const getGoogleAnalyticsPageViews = async (pagePath: string): Promise<number | null> => {
+        const propertyId = import.meta.env.GOOGLE_ANALYTICS_PROPERTY_ID;
+        const clientEmail = import.meta.env.GOOGLE_ANALYTICS_CLIENT_EMAIL;
+        const rawPrivateKey = import.meta.env.GOOGLE_ANALYTICS_PRIVATE_KEY;
+
+        if (!propertyId || !clientEmail || !rawPrivateKey) {
+                return null;
+        }
+
+        const privateKey = rawPrivateKey.replace(/\\n/g, '\n');
+        const accessToken = await requestAccessToken(clientEmail, privateKey);
+        return readPageViews(accessToken, propertyId, pagePath);
+};


### PR DESCRIPTION
## Summary
- replace the CountAPI-based blog view counter with a build-time Google Analytics lookup and cached fallback
- add a utility helper that authenticates with GA4 via service account credentials to fetch page view totals
- document the required environment variables so deployments can expose GA4 data to the in-page view badge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8fcde3f208327a6cab24ef5eaa5e6