### PR TITLE
Improve Google Analytics configuration

### DIFF
--- a/Blog/.env.example
+++ b/Blog/.env.example
@@ -18,9 +18,15 @@
 SITE_URL=https://example.com
 BASE_URL=/
 
-# Note: 
+# Note:
 # 1. Copy this file to .env and update the values
 # 2. For GitHub Pages: use /repo-name/ as BASE_URL
 # 3. For custom domain: use / as BASE_URL
 # 4. SITE_URL should not end with a slash
 # 5. BASE_URL should start and end with a slash
+
+# Google Analytics (optional but recommended for production)
+# PUBLIC_GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX
+# GOOGLE_ANALYTICS_PROPERTY_ID=123456789
+# GOOGLE_ANALYTICS_CLIENT_EMAIL=service-account@project.iam.gserviceaccount.com
+# GOOGLE_ANALYTICS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"

--- a/Blog/src/components/BaseHead.astro
+++ b/Blog/src/components/BaseHead.astro
@@ -76,7 +76,7 @@ const getAbsoluteImageUrl = (imageUrl: string) => {
 const absoluteFeaturedImage = featured_image ? getAbsoluteImageUrl(featured_image) : '';
 const absoluteOgImage = finalOgImage ? getAbsoluteImageUrl(finalOgImage) : '';
 const absoluteTwitterImage = finalTwitterImage ? getAbsoluteImageUrl(finalTwitterImage) : '';
-const measurementId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID ?? 'G-69EC1EJQ1V';
+const measurementId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID?.trim();
 ---
 
 <!-- Global Metadata -->

--- a/Blog/src/components/ViewCounter.astro
+++ b/Blog/src/components/ViewCounter.astro
@@ -10,18 +10,41 @@ const normalizedSlug = slug
         .split('/')
         .map((segment) => segment.trim())
         .filter(Boolean)
-        .join('/')
-        .toLowerCase();
-const pagePath = normalizedSlug ? `/${normalizedSlug}/` : '/';
+        .join('/');
+
+const ensureLeadingSlash = (value: string) => (value.startsWith('/') ? value : `/${value}`);
+const withoutTrailingSlash = (value: string) => (value === '/' ? value : value.replace(/\/+$/, ''));
+const withTrailingSlash = (value: string) => {
+        if (value === '/') return value;
+        const base = withoutTrailingSlash(value);
+        return `${base}/`;
+};
+
+const canonicalPath = normalizedSlug ? ensureLeadingSlash(normalizedSlug) : '/';
+
+const pathCandidates = normalizedSlug
+        ? Array.from(
+                  new Set(
+                          [
+                                  withTrailingSlash(canonicalPath),
+                                  withoutTrailingSlash(canonicalPath),
+                                  withTrailingSlash(canonicalPath).toLowerCase(),
+                                  withoutTrailingSlash(canonicalPath).toLowerCase(),
+                          ].filter(Boolean),
+                  ),
+          )
+        : ['/'];
+
+const pagePath = pathCandidates[0] ?? '/';
 const storageKey = normalizedSlug
         ? `view-counter:google-analytics:${normalizedSlug}`
         : 'view-counter:google-analytics:root';
 
 let initialCount: number | null = null;
 
-if (normalizedSlug) {
+if (normalizedSlug && pathCandidates.length > 0) {
         try {
-                initialCount = await getGoogleAnalyticsPageViews(pagePath);
+                initialCount = await getGoogleAnalyticsPageViews(pathCandidates);
         } catch (error) {
                 console.error(`Unable to resolve Google Analytics views for ${pagePath}`, error);
                 initialCount = null;


### PR DESCRIPTION
## Summary
- require the Google Analytics measurement ID to be supplied via environment variables before loading the tag
- normalize blog slugs and query multiple Google Analytics path variants so the view counter resolves recorded views
- document the required Analytics-related environment variables in the sample configuration file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d909799c388327b802f01876c2382b